### PR TITLE
Merge changes for Arduino Nano Every Compatibility into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ It is also possible to use an Arduino Micro on the eChook board, however code wi
 The main documentation for the eChook is hosted at [docs.echook.uk](https://docs.echook.uk). 
 ## Usage
 To run this code you will require the [Bounce2](https://github.com/thomasfredericks/Bounce2) library.  
-If you are updating to the new code please ensure your `Calibration.h` file is backedup. Enjoy :)
+If you are updating to the new code please ensure your `Calibration.h` file is backed up.
 
 ## Changelog
 
-12/2/19: Fixed bug that made speed read at 1/3 of actual (Thanks Apex Racing!)
+10/03/22: Tidied Button reading functions to better utilise the Bounce2 Library
+10/03/22: Added compatibility with the Arduino Nano Every board, which is the official replacement for the venerable Arduino Nano 328p
+12/02/19: Fixed bug that made speed read at 1/3 of actual (Thanks Apex Racing!)
 
 ## Modifications
 Some people have already modified the eChook to make it work exactly how they want! If you have any modifications of your own you want to share get in touch and we'll add them here.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ If you are updating to the new code please ensure your `Calibration.h` file is b
 
 ## Changelog
 
-10/03/22: Tidied Button reading functions to better utilise the Bounce2 Library
-10/03/22: Added compatibility with the Arduino Nano Every board, which is the official replacement for the venerable Arduino Nano 328p
-12/02/19: Fixed bug that made speed read at 1/3 of actual (Thanks Apex Racing!)
+- 10/03/22: Tidied Button reading functions to better utilise the Bounce2 Library
+- 10/03/22: Added compatibility with the Arduino Nano Every board, which is the official replacement for the venerable Arduino Nano 328p
+- 12/02/19: Fixed bug that made speed read at 1/3 of actual (Thanks Apex Racing!)
 
 ## Modifications
 Some people have already modified the eChook to make it work exactly how they want! If you have any modifications of your own you want to share get in touch and we'll add them here.

--- a/eChookCode/eChookCode.ino
+++ b/eChookCode/eChookCode.ino
@@ -21,7 +21,7 @@
 /** Processor Detection                */
 /** ================================== */
 // Detects if board is an Arduino Nano Every, sets flags to change code accordingly.
-#if defined(__AVR_ATMega4809__)
+#if defined(__AVR_ATmega4809__)
   #define NANO_EVERY
   // References Serial1 to SerialA for the Arduino Nano Every
   HardwareSerial &SerialA = Serial1;
@@ -129,10 +129,6 @@ volatile unsigned long fanPoll        = 0;
 Bounce launchButtonDebounce = Bounce();
 Bounce cycleButtonDebounce  = Bounce();
 Bounce brakeButtonDebounce  = Bounce();
-int cycleButtonPrevious   = LOW; // Track state so that a button press can be acted upon once
-int launchButtonPrevious  = LOW; // Track state so that a button press can be acted upon once
-int brakeButtonPrevious   = LOW; // Track state so that a button press can be acted upon once
-
 
 /** ___________________________________________________________________________________________________ Sensor Readings */
 
@@ -187,6 +183,9 @@ int speedSmoothingCount = 0;
 /** ================================== */
 void setup()
 {
+
+  
+  
 
   //Set up pin modes for all inputs and outputs
   pinMode(MOTOR_OUT_PIN,        OUTPUT);
@@ -1071,4 +1070,3 @@ void wheelSpeedISR()
 {
   wheelPoll++;
 }
-


### PR DESCRIPTION
Added Arduino Nano Every compatibility:

- Switched from hardware serial to a referenced serial object, with hardware serial port allocated according to processor (Serial on old Nano, Serial1 on Nano Every).
- Changed interruptAttach calls for Every to pin numbers.
 
Other Improvements:

- Removed legacy variables and writes
   -  Fan PWM, Fan Speed references and interrupt routine 
   -  Outputs for LEDs that were removed in V1.2 of the PCB
- Tidied Comments and header